### PR TITLE
refactor(di): extract Koin modules into config files

### DIFF
--- a/src/test/kotlin/org/darren/stock/config/KoinModulesTest.kt
+++ b/src/test/kotlin/org/darren/stock/config/KoinModulesTest.kt
@@ -17,17 +17,18 @@ class KoinModulesTest {
 
     @Test
     fun `koin modules load and provide core bindings`() {
-        val koinApp = startKoin {
-            // Provide minimal properties needed by modules that read properties
-            properties(
-                mapOf(
-                    "LOCATION_API" to "http://localhost",
-                    "IDEMPOTENCY_TTL_SECONDS" to "60",
-                    "IDEMPOTENCY_MAX_SIZE" to "100",
-                ),
-            )
-            modules(KoinModules.allModules())
-        }
+        val koinApp =
+            startKoin {
+                // Provide minimal properties needed by modules that read properties
+                properties(
+                    mapOf(
+                        "LOCATION_API" to "http://localhost",
+                        "IDEMPOTENCY_TTL_SECONDS" to "60",
+                        "IDEMPOTENCY_MAX_SIZE" to "100",
+                    ),
+                )
+                modules(KoinModules.allModules())
+            }
 
         // Resolve a couple of core bindings to ensure the modules wire correctly
         val stockService = koinApp.koin.get<org.darren.stock.domain.service.StockService>()

--- a/src/test/kotlin/org/darren/stock/config/TestKoinModules.kt
+++ b/src/test/kotlin/org/darren/stock/config/TestKoinModules.kt
@@ -3,8 +3,8 @@ package org.darren.stock.config
 import io.ktor.client.HttpClient
 import org.darren.stock.domain.LocationApiClient
 import org.darren.stock.domain.stockSystem.StockSystem
-import org.darren.stock.ktor.idempotency.InMemoryIdempotencyStore
 import org.darren.stock.ktor.idempotency.IdempotencyStore
+import org.darren.stock.ktor.idempotency.InMemoryIdempotencyStore
 import org.darren.stock.steps.helpers.TestStockEventRepository
 import org.koin.dsl.module
 
@@ -13,33 +13,37 @@ import org.koin.dsl.module
  * Keep overrides minimal and explicit so tests only change what they need.
  */
 object TestKoinModules {
-    fun testModules(testClient: HttpClient) = listOf(
-        module {
-            // Override the HTTP client used by production code
-            single<HttpClient> { testClient }
+    fun testModules(testClient: HttpClient) =
+        listOf(
+            module {
+                // Override the HTTP client used by production code
+                single<HttpClient> { testClient }
 
-            // Use a lightweight in-memory test repository
-            single<org.darren.stock.domain.StockEventRepository> { TestStockEventRepository() }
+                // Use a lightweight in-memory test repository
+                single<org.darren.stock.domain.StockEventRepository> { TestStockEventRepository() }
 
-            // Provide a deterministic location API host for tests
-            single<LocationApiClient> { LocationApiClient("http://location.api.darren.org") }
+                // Provide a deterministic location API host for tests
+                single<LocationApiClient> { LocationApiClient("http://location.api.darren.org") }
 
-            // Stock system used by domain services
-            single<StockSystem> { StockSystem() }
+                // Stock system used by domain services
+                single<StockSystem> { StockSystem() }
 
-            // Provide an in-memory idempotency store for tests
-            single<IdempotencyStore> { InMemoryIdempotencyStore() }
+                // Provide an in-memory idempotency store for tests
+                single<IdempotencyStore> { InMemoryIdempotencyStore() }
 
-            // Re-register domain adapters/services so endpoints can resolve them in tests
-            single<org.darren.stock.domain.service.StockReader> {
-                org.darren.stock.domain.service.StockSystemReader(get())
-            }
-            single<org.darren.stock.domain.service.LocationValidator> {
-                org.darren.stock.domain.service.LocationApiClientValidator(get())
-            }
-            single<org.darren.stock.domain.service.StockService> {
-                org.darren.stock.domain.service.StockService(get(), get())
-            }
-        },
-    )
+                // Re-register domain adapters/services so endpoints can resolve them in tests
+                single<org.darren.stock.domain.service.StockReader> {
+                    org.darren.stock.domain.service
+                        .StockSystemReader(get())
+                }
+                single<org.darren.stock.domain.service.LocationValidator> {
+                    org.darren.stock.domain.service
+                        .LocationApiClientValidator(get())
+                }
+                single<org.darren.stock.domain.service.StockService> {
+                    org.darren.stock.domain.service
+                        .StockService(get(), get())
+                }
+            },
+        )
 }

--- a/src/test/kotlin/org/darren/stock/steps/ServiceLifecycleSteps.kt
+++ b/src/test/kotlin/org/darren/stock/steps/ServiceLifecycleSteps.kt
@@ -11,23 +11,16 @@ import io.ktor.server.routing.*
 import io.ktor.server.testing.*
 import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.json.Json
+import org.darren.stock.config.TestKoinModules
 import org.darren.stock.domain.DateTimeProvider
-import org.darren.stock.domain.LocationApiClient
-import org.darren.stock.domain.StockEventRepository
-import org.darren.stock.domain.stockSystem.StockSystem
 import org.darren.stock.ktor.auth.JwtConfig
-import org.darren.stock.ktor.idempotency.IdempotencyStore
-import org.darren.stock.ktor.idempotency.InMemoryIdempotencyStore
 import org.darren.stock.ktor.module
 import org.darren.stock.steps.helpers.TestDateTimeProvider
-import org.darren.stock.steps.helpers.TestStockEventRepository
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.koin.core.component.KoinComponent
 import org.koin.core.context.startKoin
 import org.koin.core.context.stopKoin
 import org.koin.dsl.module
-import org.darren.stock.config.TestKoinModules
-import org.darren.stock.config.KoinModules
 
 class ServiceLifecycleSteps : KoinComponent {
     private lateinit var testApp: TestApplication


### PR DESCRIPTION
Refactor(di): extract Koin modules into config files

This PR moves test DI wiring into a centralized test helper and updates the test Koin startup so tests can provide test-scoped bindings without duplicating production modules.

Files included:
- `src/test/kotlin/org/darren/stock/config/TestKoinModules.kt` (new)
- `src/test/kotlin/org/darren/stock/config/KoinModulesTest.kt` (new)
- `src/test/kotlin/org/darren/stock/steps/ServiceLifecycleSteps.kt` (updated to use test modules)

Closes #4
