### PR TITLE
ci: fail build on Cukedoctor warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,17 @@ jobs:
       - name: Generate docs (Cukedoctor)
         run: ./gradlew cukedoctor --no-daemon --stacktrace
 
+      - name: Validate Cukedoctor output (fail on warnings)
+        run: |
+          set -o pipefail
+          echo "Running cukedoctor and checking for warnings..."
+          OUTPUT=$(./gradlew cukedoctor --no-daemon --stacktrace 2>&1)
+          echo "$OUTPUT"
+          if echo "$OUTPUT" | grep -Ei "\b(WARN|WARNING)\b"; then
+            echo "Cukedoctor produced warnings — failing CI."
+            exit 1
+          fi
+
       - name: Upload generated docs
         if: always()
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
Add CI validation step to fail the build when Cukedoctor emits warnings (enforces stricter feature-file docs quality).