### PR TITLE
test: isolate global dependencies in tests

### DIFF
--- a/src/main/kotlin/org/darren/stock/domain/stockSystem/StockSystem.kt
+++ b/src/main/kotlin/org/darren/stock/domain/stockSystem/StockSystem.kt
@@ -11,10 +11,11 @@ import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
 import java.util.concurrent.ConcurrentHashMap
 
-class StockSystem : KoinComponent {
+class StockSystem(
+    private val actorScope: CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.Default),
+) : KoinComponent {
     val locations by inject<LocationApiClient>()
     private val stockPots = ConcurrentHashMap<Pair<String, String>, SendChannel<StockPotMessages>>()
-    private val actorScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
 
     fun getStockPot(
         locationId: String,

--- a/src/test/resources/logback.xml
+++ b/src/test/resources/logback.xml
@@ -5,6 +5,10 @@
         </encoder>
     </appender>
 
+    <!-- Silence noisy Ktor internal DEBUG traces while keeping test-level debug available -->
+    <logger name="io.ktor.test" level="INFO" />
+    <logger name="io.ktor.server.engine" level="INFO" />
+
     <root level="debug">
         <appender-ref ref="STDOUT" />
     </root>


### PR DESCRIPTION
Implements test isolation: inject test CoroutineScope into StockSystem, expose and cancel the scope in test teardown, add targeted logback entries to suppress Ktor test DEBUG output. Closes #6.